### PR TITLE
Fix: Added getUserData() method in order to make it work with authsplit

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -118,4 +118,8 @@ class auth_plugin_authenvvars extends DokuWiki_Auth_Plugin {
     /* error_log( $this->userinfo['name'].': '.json_encode($grouparr) ); */
     return $grouparr;
   }
+  
+  public function getUserData($user, $requireGroups = true){
+    return true;
+  }
 }


### PR DESCRIPTION
Without this method, authsplit fails for me when using authenvvars as primary authentication adapter. The reason is, that authsplit tries to call it.
By adding this "dummy" method, everything works fine on my end.